### PR TITLE
Py3k: Fix initial issues throwing syntax errors with Py3k

### DIFF
--- a/certidude/api/request.py
+++ b/certidude/api/request.py
@@ -85,7 +85,7 @@ class RequestListResource(object):
 
                 try:
                     renewal_signature = b64decode(renewal_header)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     logger.error(u"Renewal failed, bad signature supplied for %s", common_name)
                     reasons.append("Renewal failed, bad signature supplied")
                 else:

--- a/certidude/api/scep.py
+++ b/certidude/api/scep.py
@@ -139,7 +139,7 @@ class SCEPResource(object):
             signed_certificate = asymmetric.load_certificate(buf)
             content = signed_certificate.asn1.dump()
 
-        except SCEPError, e:
+        except SCEPError as e:
             attr_list.append(cms.CMSAttribute({
                 'type': u"fail_info",
                 'values': ["%d" % e.code]

--- a/certidude/cli.py
+++ b/certidude/cli.py
@@ -1278,7 +1278,7 @@ def certidude_serve(port, listen, fork):
     if not os.path.exists(const.RUN_DIR):
         click.echo("Creating: %s" % const.RUN_DIR)
         os.makedirs(const.RUN_DIR)
-        os.chmod(const.RUN_DIR, 0755)
+        os.chmod(const.RUN_DIR, 0o755)
 
     # TODO: umask!
 

--- a/certidude/cli.py
+++ b/certidude/cli.py
@@ -18,7 +18,7 @@ from configparser import ConfigParser, NoOptionError, NoSectionError
 from certidude.common import ip_address, ip_network, apt, rpm, pip, drop_privileges, selinux_fixup
 from datetime import datetime, timedelta
 from time import sleep
-import const
+from . import const
 
 logger = logging.getLogger(__name__)
 

--- a/certidude/cli.py
+++ b/certidude/cli.py
@@ -1128,9 +1128,9 @@ def certidude_users():
     from certidude.user import User
     admins = set(User.objects.filter_admins())
     for user in User.objects.all():
-        print "%s;%s;%s;%s;%s" % (
+        print ("%s;%s;%s;%s;%s" % (
             "admin" if user in admins else "user",
-            user.name, user.given_name, user.surname, user.mail)
+            user.name, user.given_name, user.surname, user.mail))
 
 
 @click.command("list", help="List certificates")
@@ -1200,7 +1200,7 @@ def certidude_list(verbose, show_key_type, show_extensions, show_path, show_sign
             click.echo("openssl x509 -in %s -text -noout" % path)
             dump_common(common_name, path, cert)
             for ext in cert["tbs_certificate"]["extensions"]:
-                print " - %s: %s" % (ext["extn_id"].native, repr(ext["extn_value"].native))
+                print (" - %s: %s" % (ext["extn_id"].native, repr(ext["extn_value"].native)))
 
     if show_revoked:
         for common_name, path, buf, cert, server in authority.list_revoked():
@@ -1217,7 +1217,7 @@ def certidude_list(verbose, show_key_type, show_extensions, show_path, show_sign
             click.echo("openssl x509 -in %s -text -noout" % path)
             dump_common(common_name, path, cert)
             for ext in cert["tbs_certificate"]["extensions"]:
-                print " - %s: %s" % (ext["extn_id"].native, repr(ext["extn_value"].native))
+                print (" - %s: %s" % (ext["extn_id"].native, repr(ext["extn_value"].native)))
 
 
 @click.command("sign", help="Sign certificate")

--- a/certidude/config.py
+++ b/certidude/config.py
@@ -5,7 +5,7 @@ import configparser
 import ipaddress
 import os
 import string
-import const
+from . import const
 from random import choice
 
 # Options that are parsed from config file are fetched here

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,7 +152,7 @@ def test_cli_setup_authority():
         with open(util, "w") as fh:
             fh.write("#!/bin/bash\n")
             fh.write("exit 0\n")
-        os.chmod(util, 0755)
+        os.chmod(util, 0o755)
     if not os.path.exists("/etc/pki/ca-trust/source/anchors/"):
         os.makedirs("/etc/pki/ca-trust/source/anchors/")
 
@@ -198,7 +198,7 @@ def test_cli_setup_authority():
     if os.path.exists("/etc/krb5.keytab"):
         os.unlink("/etc/krb5.keytab")
     os.symlink("/var/lib/samba/private/secrets.keytab", "/etc/krb5.keytab")
-    os.chmod("/var/lib/samba/private/secrets.keytab", 0644) # To allow access to certidude server
+    os.chmod("/var/lib/samba/private/secrets.keytab", 0o644) # To allow access to certidude server
     if os.path.exists("/etc/krb5.conf"): # Remove the one from krb5-user package
         os.unlink("/etc/krb5.conf")
     os.symlink("/var/lib/samba/private/krb5.conf", "/etc/krb5.conf")
@@ -227,11 +227,11 @@ def test_cli_setup_authority():
 
     result = runner.invoke(cli, ['setup', 'authority', '-s'])
     os.setgid(0) # Restore GID
-    os.umask(0022)
+    os.umask(0o022)
 
     result = runner.invoke(cli, ['setup', 'authority']) # For if-else branches
     os.setgid(0) # Restore GID
-    os.umask(0022)
+    os.umask(0o022)
 
     # Make sure nginx is running
     assert not result.exception, result.output
@@ -1280,7 +1280,7 @@ def test_cli_setup_authority():
     ### SCEP tests ###
     ##################
 
-    os.umask(0022)
+    os.umask(0o022)
     if not os.path.exists("/tmp/sscep"):
         assert not os.system("git clone  https://github.com/certnanny/sscep /tmp/sscep")
     if not os.path.exists("/tmp/sscep/sscep_dyn"):


### PR DESCRIPTION
Now I can get to the point where `pip install -e .` works and I can run `certidude` command.